### PR TITLE
Link to async fn in traits workaround

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -61,3 +61,8 @@ async_extensions:
       - title: "Generic associated types (GAT)"
         rfc: "1598-generic_associated_types"
         tracking: 44265
+
+      - title: "Workaround is available as an attribute macro:"
+        link:
+          text: "`async-trait`"
+          url: https://github.com/dtolnay/async-trait

--- a/src/data/input.rs
+++ b/src/data/input.rs
@@ -1,4 +1,4 @@
-use super::IssueId;
+use super::{IssueId, Link};
 use crate::query::Repo;
 use crate::{RFC_REPO, RUSTC_REPO};
 use serde::Deserialize;
@@ -17,6 +17,7 @@ pub struct Item {
     pub issue_label: Option<String>,
     pub stabilized: Option<Stabilization>,
     pub unresolved: Option<String>,
+    pub link: Option<Link>,
     #[serde(default)]
     pub deps: Vec<Item>,
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -11,3 +11,9 @@ pub struct Issue {
     pub title: String,
     pub open: bool,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Link {
+    pub text: String,
+    pub url: String,
+}

--- a/src/data/output.rs
+++ b/src/data/output.rs
@@ -1,5 +1,5 @@
 use super::input::{InputData, Item as InputItem};
-use super::{Issue, IssueId};
+use super::{Issue, IssueId, Link};
 use crate::fetcher::IssueData;
 use crate::query::Repo;
 use crate::{RFC_REPO, RUSTC_REPO};
@@ -28,6 +28,7 @@ pub struct Item {
     pub issues: Vec<Issue>,
     pub stabilized: Option<Stabilization>,
     pub unresolved: Option<Rfc>,
+    pub link: Option<Link>,
     pub deps: Vec<Item>,
 }
 
@@ -99,6 +100,7 @@ impl Builder<'_> {
                 pr: self.get_issue(&*RUSTC_REPO, stabilized.pr),
             }),
             unresolved: self.convert_rfc(item.unresolved),
+            link: item.link,
             deps: self.convert_items(item.deps),
         }
     }

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -10,6 +10,7 @@
       {%- endif %}
       {%- if item.link %}
         <a href="{{ item.link.url }}">{{ item.link.text | codify }}</a>
+        {%- continue %}
       {%- endif %}
       {%- if not item.stabilized %}
         <span class="not-stabilized">not stabilized yet</span>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -8,6 +8,9 @@
           title="{{ item.unresolved.issue.title }}">unresolved</a>
         {%- continue %}
       {%- endif %}
+      {%- if item.link %}
+        <a href="{{ item.link.url }}">{{ item.link.text | codify }}</a>
+      {%- endif %}
       {%- if not item.stabilized %}
         <span class="not-stabilized">not stabilized yet</span>
       {%- else %}


### PR DESCRIPTION
## Description
Link to the [async-trait](https://github.com/dtolnay/async-trait) crate which unblocks most use cases for async in traits. It will be usable on stable as soon as async fn is available -- no need to wait for GAT.

## Motivation and Context
https://twitter.com/rustasync/status/1155747027847983106

## How Has This Been Tested?
![Screenshot from 2019-08-03 11-46-29](https://user-images.githubusercontent.com/1940490/62415800-639e4b00-b5e4-11e9-9ae9-d8e3e9b1c1bc.png)