### PR TITLE
Replace archived actions-rs/toolchain with rustup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,9 +27,10 @@ jobs:
         uses: actions/configure-pages@v2
       - name: Setup Rust toolchain
         id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          echo "rustc_hash=$(rustc -vV | sed -n 's/^commit-hash: //p')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Cargo
         uses: actions/cache@v3


### PR DESCRIPTION
actions-rs/toolchain has been archived for a while now, so this swaps it in CI for rustup directly. The runner already ships rustup, and the toolchain stays the same as before. The step keeps its id and now exports rustc_hash itself, since the cache keys below still depend on it.
This is part of a wider effort to remove archived actions across rust-lang repos, tracked in rust-lang/crabwatch#49.
